### PR TITLE
Adding a delay_b state to the task

### DIFF
--- a/delay_out_center_task/machine.py
+++ b/delay_out_center_task/machine.py
@@ -250,6 +250,7 @@ states \
        'delay_a',
        'move_b',
        'hold_b',
+       'delay_b',
        'move_c',
        'hold_c',
       ]
@@ -278,19 +279,21 @@ state_transitions \
     + [
        dict(trigger='target_engaged',    source='move_a',     dest='hold_a'),
        dict(trigger='timeout',           source='move_a',     dest='failure'),
-       dict(trigger='target_disengaged', source='hold_a',     dest='failure'),
        dict(trigger='timeout',           source='hold_a',     dest='delay_a'),
-       dict(trigger='target_disengaged', source='delay_a',    dest='failure'),
+       dict(trigger='target_disengaged', source='hold_a',     dest='failure'),
        dict(trigger='timeout',           source='delay_a',    dest='move_b'),
-       dict(trigger='timeout',           source='move_b',     dest='failure'),
+       dict(trigger='target_disengaged', source='delay_a',    dest='failure'),
        dict(trigger='target_engaged',    source='move_b',     dest='hold_b'),
        dict(trigger='timeout',           source='move_b',     dest='failure'),
+       dict(trigger='timeout',           source='hold_b',     dest='delay_b'),
        dict(trigger='target_disengaged', source='hold_b',     dest='failure'),
-       dict(trigger='timeout',           source='hold_b',     dest='move_c'),
+       dict(trigger='timeout',           source='delay_b',    dest='move_c'),
+       dict(trigger='target_disengaged', source='delay_b',    dest='failure'),
        dict(trigger='target_engaged',    source='move_c',     dest='hold_c'),
        dict(trigger='timeout',           source='move_c',     dest='failure'),
-       dict(trigger='target_disengaged', source='hold_c',     dest='failure'),
        dict(trigger='timeout',           source='hold_c',     dest='success'),
+       dict(trigger='timeout',           source='move_c',     dest='failure'),
+       dict(trigger='target_disengaged', source='hold_c',     dest='failure'),
       ]
 """
 State transitions of the delayed center-out, out-center cursor task.

--- a/delay_out_center_task/model.py
+++ b/delay_out_center_task/model.py
@@ -343,6 +343,7 @@ class Model:
         set_default('timeout_s.move_a',     2.000)
         set_default('timeout_s.hold_a',     0.500)
         set_default('timeout_s.delay_a',    0.500)
+        set_default('timeout_s.delay_b',    0.500)
         set_default('timeout_s.move_b',     1.000)
         set_default('timeout_s.hold_b',     0.500)
         set_default('timeout_s.move_c',     1.000)
@@ -693,6 +694,41 @@ class Model:
         
         # Reset the timeout timer.
         self.cancel_timeout()
+        
+    def on_enter_delay_b(self, event_data=None):
+        """ Initialize the "delay_b" state. """
+        
+        # Initialize the cue.
+        self.environment.initialize_sphere('cue')        
+        
+        # Initialize shorthand.
+        #target_key = list(self.targets)[self.target_index]
+        #target = self.targets[target_key]
+        self.log(f'Setting target cue: origin')
+        
+        # Update the cue, such that it matches the appearance of the active 
+        # target (NOT the home target).
+        self.update_target_radius(key='cue')
+        self.update_target_color(key='cue')
+        
+        # Set the cue position.
+        #xyz = target['position']
+        self.environment.set_position(0.0,0.0,0.0, key='cue')
+        
+        # Move the target to the home position.
+        #self.set_home_target()
+        
+        # Set the timeout timer.
+        self.set_parameterized_timeout('delay_b')
+        
+    def on_exit_delay_b(self, event_data=None):
+        """ Terminate the "delay_b" state. """
+        
+        # Reset the timeout timer.
+        self.cancel_timeout()
+        
+        # Initialize the cue.
+        self.environment.destroy_sphere('cue')    
         
     def on_enter_move_c(self, event_data=None):
         """ Initialize the "move_c" state. """


### PR DESCRIPTION
Changes were made to add a `delay_b` state to the task. This state is comparable to the existing `delay_a` state. This has been tested in place, but not systematically. It is a minor change and no issue are anticipated.

@Jshulgach did the work.