### PR TITLE
Added delays to trial setup / teardown and updated doctests for the model

### DIFF
--- a/delay_out_center_task/machine.py
+++ b/delay_out_center_task/machine.py
@@ -223,7 +223,7 @@ State: inactive
 """
 
 
-# Copyright 2022 Carnegie Mellon University Neuromechatronics Lab (a.whit)
+# Copyright 2022-2023 Carnegie Mellon University Neuromechatronics Lab (a.whit)
 # 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/delay_out_center_task/machine.py
+++ b/delay_out_center_task/machine.py
@@ -70,6 +70,8 @@ State: move_b
 >>> success = trigger('target_engaged')
 State: hold_b
 >>> success = trigger('timeout')
+State: delay_b
+>>> success = trigger('timeout')
 State: move_c
 >>> success = trigger('target_engaged')
 State: hold_c
@@ -94,6 +96,8 @@ State: delay_a
 State: move_b
 >>> success = trigger('target_engaged')
 State: hold_b
+>>> success = trigger('timeout')
+State: delay_b
 >>> success = trigger('timeout')
 State: move_c
 >>> success = trigger('target_engaged')
@@ -120,6 +124,8 @@ State: move_b
 >>> success = trigger('target_engaged')
 State: hold_b
 >>> success = trigger('timeout')
+State: delay_b
+>>> success = trigger('timeout')
 State: move_c
 >>> success = trigger('timeout')
 State: failure
@@ -142,6 +148,32 @@ State: delay_a
 State: move_b
 >>> success = trigger('target_engaged')
 State: hold_b
+>>> success = trigger('timeout')
+State: delay_b
+>>> success = trigger('target_disengaged')
+State: failure
+>>> success = trigger('timeout')
+State: trial_teardown
+>>> success = trigger('end_trial')
+State: intertrial
+
+Step through the state sequence of a trial that fails during the `delay_b` 
+phase.
+
+>>> success = trigger('timeout')
+State: trial_setup
+>>> success = machine.model.to_move_a()  # Manual transition to trial state 1.
+State: move_a
+>>> success = trigger('target_engaged')
+State: hold_a
+>>> success = trigger('timeout')
+State: delay_a
+>>> success = trigger('timeout')
+State: move_b
+>>> success = trigger('target_engaged')
+State: hold_b
+>>> success = trigger('timeout')
+State: delay_b
 >>> success = trigger('target_disengaged')
 State: failure
 >>> success = trigger('timeout')

--- a/delay_out_center_task/model.py
+++ b/delay_out_center_task/model.py
@@ -531,8 +531,8 @@ class Model:
     def on_enter_inactive(self, event_data=None):
         """ Initialize the "inactive" state. """
         
-        # Destroy all objects in the environment ~~, except the cursor.~~
-        keys = [k for k in self.environment] # if (k != 'cursor')]
+        # Destroy all objects in the environment, except the cursor.
+        keys = [k for k in self.environment if (k != 'cursor')]
         for k in keys: self.environment.destroy_object(k)
         
         #pass

--- a/delay_out_center_task/model.py
+++ b/delay_out_center_task/model.py
@@ -249,10 +249,8 @@ As the trial ends, the target is destroyed.
 
 >>> environment.exists('target')
 True
->>> delta = time_timeout(model.on_enter_trial_teardown)
+>>> model.on_enter_trial_teardown()
 Trigger: end_trial
->>> abs(delta - model.parameters['timeout_s.trial_teardown']) < tol
-True
 >>> environment.exists('target')
 False
 

--- a/delay_out_center_task/model.py
+++ b/delay_out_center_task/model.py
@@ -741,10 +741,11 @@ class Model:
         #target = self.targets[target_key]
         self.log(f'Setting target cue: origin')
         
-        # Update the cue, such that it matches the appearance of the active 
-        # target (NOT the home target).
-        self.update_target_radius(key='cue')
-        self.update_target_color(key='cue')
+        # Update the cue, such that it matches the appearance of the home 
+        # Use the current parameter values, rather than the active target 
+        # values. The home target will always have the same appearance.
+        self.update_target_radius(key='cue', from_active_target=False)
+        self.update_target_color(key='cue', from_active_target=False)
         
         # Set the cue position.
         #xyz = target['position']

--- a/delay_out_center_task/model.py
+++ b/delay_out_center_task/model.py
@@ -362,8 +362,8 @@ class Model:
         set_default('timeout_s.failure',    0.200)
         set_default('timeout_s.success',    0.010)
         set_default('timeout_s.intertrial', 0.005)
-        set_default('timeout_s.trial_setup', 0.010)
-        set_default('timeout_s.trial_teardown', 0.010)
+        #set_default('timeout_s.trial_setup', 0.010)
+        #set_default('timeout_s.trial_teardown', 0.010)
         
         # Initialize default sphere parameters.
         set_default('cursor.radius',  0.1)
@@ -574,13 +574,13 @@ class Model:
         create a target. Derived classes should override this state to 
         implement some sort of automatic transition to the task-specific 
         initial state of a trial.
-        
-        In general, this could be a pass-through state, but a delay is imposed 
-        in order to allow any actions time to take effect.
         """
         
         # Create the target.
         self.environment.initialize_sphere('target')
+        
+        # Ensure that the target does not yet affect the task.
+        self.environment.set_radius(0, key='target')
         
         # Set a random target index.
         self.target_index = self.choose_random_target_index()
@@ -588,19 +588,21 @@ class Model:
         # Update the cursor.
         self.update_cursor_radius()
         self.update_cursor_color()
+        # Consider either moving this to the block level, or making it 
+        # instantaneous.
         
-        ## Insert an automatic transition to the initial, task-specific state 
-        ## of a trial.
-        #self.to_move_a()
+        # Insert an automatic transition to the initial, task-specific state 
+        # of a trial.
+        self.to_move_a()
         
-        # Set the timeout timer.
-        self.set_parameterized_timeout('trial_setup', callback=self.to_move_a)
+        ## Set the timeout timer.
+        #self.set_parameterized_timeout('trial_setup', callback=self.to_move_a)
         
-    def on_exit_trial_setup(self, event_data=None):
-        """ Terminate the "trial_setup" state. """
-        
-        # Reset the timeout timer.
-        self.cancel_timeout()
+    #def on_exit_trial_setup(self, event_data=None):
+    #    """ Terminate the "trial_setup" state. """
+    #    
+    #    # Reset the timeout timer.
+    #    self.cancel_timeout()
         
     def on_enter_trial_teardown(self, event_data=None):
         """ Tear-down a trial.
@@ -614,18 +616,18 @@ class Model:
         # Clear the target.
         self.environment.destroy_sphere('target')
         
-        ## Automatically transition to the intertrial state.
-        #self.trigger('end_trial')
+        # Automatically transition to the intertrial state.
+        self.trigger('end_trial')
     
-        # Set the timeout timer.
-        callback = lambda: self.trigger('end_trial')
-        self.set_parameterized_timeout('trial_teardown', callback=callback)
+        ## Set the timeout timer.
+        #callback = lambda: self.trigger('end_trial')
+        #self.set_parameterized_timeout('trial_teardown', callback=callback)
         
-    def on_exit_trial_teardown(self, event_data=None):
-        """ Terminate the "trial_setup" state. """
-        
-        # Reset the timeout timer.
-        self.cancel_timeout()
+    #def on_exit_trial_teardown(self, event_data=None):
+    #    """ Terminate the "trial_setup" state. """
+    #    
+    #    # Reset the timeout timer.
+    #    self.cancel_timeout()
         
     def on_enter_move_a(self, event_data=None):
         """ Initialize the "move_a" state. """


### PR DESCRIPTION
Added delays the trial_setup and trial_teardown states (to allow time… for processing of actions) and updated the doctests for both this change and the addition of the hold_b state. The doctests pass, but more extensive testing might be warranted.